### PR TITLE
Modification to Backtrace to use output ranges instead of File.

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,6 +5,15 @@
   "copyright": "Copyright © 2013, Yazan Dabain",
   "authors": ["Yazan Dabain"],
   "targetType": "sourceLibrary",
-  "license": "BSL-1.0"
+  "license": "BSL-1.0",
+
+  "configurations":
+  [
+    {
+      "name": "sample",
+      "targetType": "executable",
+      "mainSourceFile": "sample/sample.d"
+    }
+  ]
 }
 

--- a/sample/sample.d
+++ b/sample/sample.d
@@ -1,0 +1,71 @@
+//Written in the D programming language
+
+/*
+ * Sample program to demonstrate Backtrace.
+ *
+ * Written by: Jason den Dulk.
+ */
+
+module sample;
+
+import std.conv;
+import std.string;
+import std.array;
+import std.algorithm;
+import std.stdio;
+
+import backtrace;
+
+void toStdout() {
+  writeln("#");
+  writeln("# Pretty trace direct to stdout.");
+  writeln("#");
+  printPrettyTrace();
+}
+
+void toStderr() {
+  writeln("#");
+  writeln("# Pretty trace direct to stderr.");
+  writeln("#");
+  printPrettyTrace(stderr);
+}
+
+void asString() {
+  writeln("#");
+  writeln("# Pretty trace as a string");
+  writeln("#");
+  write(prettyTrace());
+}
+
+void onException() {
+  writeln("#");
+  writeln("# Pretty trace after an exception");
+  writeln("#");
+  throw new Exception("FAIL!");
+}
+
+void onError() {
+  writeln("#");
+  writeln("# Pretty trace after an error");
+  writeln("#");
+  int[] x = [1,2,3];
+  int y = x[5]; // Range violation;
+}
+
+void main() {
+  backtrace.install();
+  writeln("### Backtrace Sample Demo. ###");
+  toStdout();
+  toStderr();
+  asString();
+  try {
+    onException();
+  } catch (Exception e) {
+    writeln("# Line by line");
+    foreach (i,l;e.info)
+      writeln(i,": ",l);
+    writeln("# via Throwable.toString()");
+    write(e.toString());
+  }
+  onError();
+}

--- a/source/backtrace/backtrace.d
+++ b/source/backtrace/backtrace.d
@@ -145,7 +145,7 @@ void printPrettyTrace(PrintOptions options = PrintOptions.init, uint framesToSki
 
 void printPrettyTrace(File output, PrintOptions options = PrintOptions.init, uint framesToSkip = 1) {
   void*[] bt = getBacktrace();
-  auto or = stdout.lockingTextWriter();
+  auto or = output.lockingTextWriter();
   printPrettyTrace(bt, or, options, framesToSkip);
 }
 


### PR DESCRIPTION
I would like to have considered some changes to the backtrace module.

Generally I have refactored the module to use output ranges instead of `File`. The changes are as follows:

- Refactored `private printPrettyTrace` to use output ranges instead of `File`.
- Added function `printPrettyTrace(OR)(ref OR output ...)`
- Modified `printPrettyTrace` to call `private printPrettyTrace` using `File.lockingTextWriter`.
- `BTTraceHandler` now implements `opApply` to use the delegates provided.
- `BTTraceHandler` now implements `toString`.
- `runtimeOutputFile` has been removed as it is not used.
- A new install function that doesn't take a `File` is provided.

Note that `opApply` will not notice `break` statements. To do this would require `printPrettyTrace` to be refactored again to act as an input range (Although I have since thought of a 'quick and dirty' solution).

Thank you for your consideration
Regards
Jason
